### PR TITLE
13 item 18 상속보다는 컴포지션을 사용하라

### DIFF
--- a/src/main/java/org/jsh/chapter04/item18/InstrumentedHashSet.java
+++ b/src/main/java/org/jsh/chapter04/item18/InstrumentedHashSet.java
@@ -2,27 +2,29 @@ package org.jsh.chapter04.item18;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 // 상속을 잘못 사용한 예
-public class InstrumentedHashSet<E> extends HashSet<E> {
+public class InstrumentedHashSet<E> {
     // 추가된 원소의 수
     private int addCount = 0;
+    private final Set<E> set;
 
-    public InstrumentedHashSet() {
+    public InstrumentedHashSet(Set<E> set) {
+        this.set = set;
     }
 
-    @Override
     public boolean add(E e) {
         addCount++;
-        return super.add(e);
+        return set.add(e);
     }
 
-    @Override
     public boolean addAll(Collection<? extends E> c) {
         addCount += c.size();
-        // 여기서 문제 발생!
-        // HashSet의 addAll은 내부적으로 add를 호출함 -> addCount가 또 올라감 (Double Counting)
-        return super.addAll(c);
+        // 상속과 달리 set.addAll()이 내부적으로 set.add()를 호출하더라도
+        // 그것은 저쪽 set 객체의 add이지, InstrumentedSet의 add가 아님
+        // 따라서 addCount가 중복으로 증가하지 않음
+        return set.addAll(c);
     }
 
     public int getAddCount() {

--- a/src/test/java/org/jsh/chapter04/item18/InstrumentedHashSetTest.java
+++ b/src/test/java/org/jsh/chapter04/item18/InstrumentedHashSetTest.java
@@ -1,0 +1,29 @@
+package org.jsh.chapter04.item18;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import static org.assertj.core.api.Assertions.*;
+
+class InstrumentedHashSetTest {
+
+    @Test
+    @DisplayName("상속 사용 시 더블 카운팅 버그 테스트")
+    void doubleCountingTest() {
+        // Given
+        InstrumentedHashSet<String> s = new InstrumentedHashSet<>(new HashSet<String>());
+
+        // When
+        // 리스트의 원소 3개를 한 번에 추가
+        s.addAll(List.of("틱", "탁", "톡"));
+
+        // Then
+        // 예상: 3
+        // 실제: 6 (addAll에서 +3, 내부 add 호출되면서 각각 +1씩 3번 더해짐)
+        // Before 코드는 여기서 실패해야 함
+        assertThat(s.getAddCount()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
## 📘 Item 18: 상속보다는 컴포지션을 사용하라

### 🔗 Related Issue
Closes #13 

---

### 🚩 Problem (Before)
> 상속(Inheritance)의 취약점: 캡슐화 위배
- `HashSet`을 상속받아 `addCount` 기능을 추가했으나, `addAll` 메서드가 내부적으로 `add`를 호출하는 `HashSet`의 구현 세부사항(Self-use) 때문에 카운트가 중복으로 증가하는 버그 발생.
- 상위 클래스(`HashSet`)의 내부 구현 방식에 따라 하위 클래스의 동작이 깨질 수 있음.

---

### ✅ Solution (After)
> 컴포지션(Composition)과 전달(Forwarding) 적용
- `extends HashSet`을 제거하고, `private final Set<E> set` 필드를 두어 인스턴스를 감싸는 구조(Wrapper Class)로 변경.
- **결과:** `addAll`을 호출해도 내부의 `Set` 인스턴스에 작업을 위임할 뿐, 내 클래스의 `add`를 다시 호출하지 않으므로 **더블 카운팅 문제가 완벽하게 해결됨.**
- 유연성: `HashSet` 뿐만 아니라 `TreeSet`, `ArrayList` 등 어떤 `Set` 구현체도 감싸서 카운팅 기능을 추가할 수 있게 됨.

```java
// 생성자로 주입받은 set 인스턴스에게 실제 저장 로직을 위임
public boolean addAll(Collection<? extends E> c) {
    addCount += c.size();
    return set.addAll(c); // 여기서 내부적으로 add가 호출되어도 카운트 영향 없음
}

```

---

### 📝 Review & Feedback

> AI(Gemini)와의 리뷰 과정에서 배운 점

* 상속은 "is-a" 관계일 때만 써야 하며, 단순히 코드 재사용을 위해 상속을 쓰면 내부 구현 의존성 때문에 코드가 깨지기 쉽다.
* 컴포지션(Wrapper)을 사용하면 기존 클래스의 내부 구현을 몰라도 안전하게 기능을 확장(Decorator Pattern)할 수 있다.

---

### 🧪 Verification

* [x] `addAll` 호출 시 카운트가 정확히 요소 개수만큼만 증가하는지 검증 (`Expected: 3`, `Actual: 3` -> Pass)