### PR TITLE
23 item 53 가변인수는 신중히 사용하라

### DIFF
--- a/src/main/java/org/jsh/chapter08/item53/Varargs.java
+++ b/src/main/java/org/jsh/chapter08/item53/Varargs.java
@@ -2,13 +2,9 @@ package org.jsh.chapter08.item53;
 
 public class Varargs {
 
-    // Bad: 0개의 인수가 들어오면 런타임에 실패함
-    public static int min(int... args) {
-        if (args.length == 0)
-            throw new IllegalArgumentException("인수가 1개 이상 필요합니다.");
-
-        int min = args[0];
-        for (int i = 1; i < args.length; i++) {
+    // 첫 번째 인자를 입력하게 강제하여, 잘못된 값을 넣을 시 컴파일 에러를 유도
+    public static int min(int min, int... args) {
+        for (int i = 0; i < args.length; i++) {
             if (args[i] < min)
                 min = args[i];
         }

--- a/src/test/java/org/jsh/chapter08/item53/VarargsTest.java
+++ b/src/test/java/org/jsh/chapter08/item53/VarargsTest.java
@@ -15,7 +15,7 @@ class VarargsTest {
 
         // 2. 문제 상황: 인수를 0개 넣어도 컴파일은 됨 (실행해야 에러 발생)
         // After 리팩토링 후에는: min() 호출 자체가 컴파일 에러가 나야 함
-        assertThatThrownBy(() -> Varargs.min())
-                .isInstanceOf(IllegalArgumentException.class);
+        //assertThatThrownBy(() -> Varargs.min())
+        //        .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## 📘 [Item 53] 가변인수는 신중히 사용하라

### 🔗 Related Issue

Closes #23 

---

### 🚩 Problem (Before)

> 인수가 0개일 때의 런타임 위험성

* `min(int... args)` 형태로 정의하면, 호출자가 인수를 하나도 넣지 않고 `min()`을 호출해도 컴파일러가 막지 않음.
* 실행 시점(Runtime)에 `args.length`를 체크하여 예외를 던져야 하므로, 코드가 지저분해지고 오류를 늦게 발견하게 됨.

---

### ✅ Solution (After)

> '1+N' 인수 패턴 적용

* 메서드 시그니처를 `min(int min, int... args)`로 변경.
* **첫 번째 인수(`int min`)를 강제**함으로써, 인수가 없는 호출 자체를 **컴파일 에러**로 원천 봉쇄함.
* 내부 로직에서도 명시적인 유효성 검사(`if length == 0`) 코드를 제거하여 더 깔끔해짐.

```java
// 컴파일러가 최소 1개의 인수를 보장함
public static int min(int min, int... args) { ... }

```

---

### 📝 Review & Feedback

> AI(Gemini)와의 리뷰 과정에서 배운 점

* 가변인수는 편리하지만, "최소 1개 이상" 같은 제약 조건을 걸 때는 부적절할 수 있음.
* 필수 인자는 일반 매개변수로 빼고, 선택적인 나머지 인자만 가변인수로 받는 것이 더 안전한 API 설계임.

---

### 🧪 Verification

* [x] `min(3, 1, 2)` 정상 동작 확인 (`VarargsTest Pass`)
* [x] `min()` (인수 0개) 호출 시 컴파일 에러 발생하여 테스트 코드에서 해당 케이스 삭제 완료.