### PR TITLE
25 item 55 옵셔널 반환은 신중히 하라

### DIFF
--- a/src/main/java/org/jsh/chapter08/item55/Max.java
+++ b/src/main/java/org/jsh/chapter08/item55/Max.java
@@ -1,6 +1,7 @@
 package org.jsh.chapter08.item55;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -17,5 +18,9 @@ public class Max {
                 result = Objects.requireNonNull(e);
         }
         return Optional.of(result);
+    }
+
+    public static <E extends Comparable<E>> Optional<E> maxStream(Collection<E> c) {
+        return c.stream().max(Comparator.naturalOrder());
     }
 }

--- a/src/test/java/org/jsh/chapter08/item55/MaxTest.java
+++ b/src/test/java/org/jsh/chapter08/item55/MaxTest.java
@@ -24,4 +24,20 @@ class MaxTest {
         //        .hasMessage("빈 컬렉션입니다.");
         assertThat(Max.max(List.<Integer>of())).isEqualTo(Optional.empty());
     }
+
+    @Test
+    @DisplayName("최댓값 구하기 및 빈 컬렉션 예외 확인(Stream 적용)")
+    void maxStreamTest() {
+        // Given
+        List<Integer> list = List.of(1, 3, 2);
+
+        // When & Then (정상 케이스)
+        assertThat(Max.maxStream(list)).contains(3);
+
+        // When & Then (예외 케이스)
+        //assertThatThrownBy(() -> Max.max(List.<Integer>of()))
+        //        .isInstanceOf(IllegalArgumentException.class)
+        //        .hasMessage("빈 컬렉션입니다.");
+        assertThat(Max.maxStream(List.<Integer>of())).isEqualTo(Optional.empty());
+    }
 }


### PR DESCRIPTION
## 📘 [Item 55] 옵셔널 반환은 신중히 하라

### 🔗 Related Issue

Closes #25 

---

### 🚩 Problem (Before)

> 빈 컬렉션 처리 시 예외 발생의 위험성

* 컬렉션이 비었을 때 `IllegalArgumentException`을 던지도록 구현됨.
* 클라이언트가 빈 컬렉션인지 미리 체크하지 않으면 런타임 에러가 발생하여 시스템 안정성 저하.

---

### ✅ Solution (After)

> `Optional<T>` 반환을 통한 명시적 처리 강제

* 반환 타입을 `Optional<E>`로 변경하여, "반환값이 없을 수도 있음"을 API 수준에서 명시.
* 빈 컬렉션일 경우 예외 대신 `Optional.empty()`를 명시적으로 반환.
* 값이 있을 경우 `Optional.of(result)`로 감싸서 반환하도록 리팩토링.

```java
// 루프를 사용한 Optional 처리
public static <E extends Comparable<E>> Optional<E> max(Collection<E> c) {
    if (c.isEmpty())
        return Optional.empty(); // 빈 상자 반환

    E result = null;
    for (E e : c) {
        if (result == null || e.compareTo(result) > 0)
            result = Objects.requireNonNull(e);
    }
    return Optional.of(result);
}

```

---

### 📝 Review & Feedback

> AI(Gemini)와의 리뷰 과정에서 배운 점 (Stream 활용)

* `Stream`을 사용하면 훨씬 간결하게 동일한 로직을 구현할 수 있음을 배움.
* `Stream.max` 메서드는 기본적으로 `Optional`을 반환하도록 설계되어 있어, 별도의 `isEmpty` 체크나 `Optional` 포장이 필요 없음.

```java
// Tip: 스트림을 활용한 더 간결한 방법
public static <E extends Comparable<E>> Optional<E> maxStream(Collection<E> c) {
    return c.stream().max(Comparator.naturalOrder());
}

```

---

### 🧪 Verification

* [x] `Max.max()` 호출 시:
* 정상 리스트 입력 -> 최댓값이 담긴 Optional 반환 확인
* 빈 리스트 입력 -> `Optional.empty()` 반환 확인 (`isEqualTo(Optional.empty())`)