### PR TITLE
feat: javadoc 추가

### DIFF
--- a/src/main/java/org/jsh/chapter08/item55/Max.java
+++ b/src/main/java/org/jsh/chapter08/item55/Max.java
@@ -6,8 +6,23 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class Max {
-    // Before: 빈 컬렉션이면 예외를 던짐 (과격한 처리)
-    // After : 빈 컬렉션일 경우 빈 Optional을, 있는 경우 Optional로 감싸서 반환
+
+    /**
+     * 컬렉션에서 최댓값을 반환합니다.
+     * <p>
+     * 이 메서드는 {@link Comparable} 인터페이스를 구현한 요소들로 구성된 컬렉션을 받아,
+     * 그중 가장 큰 요소를 {@link Optional}로 감싸서 반환합니다.
+     * </p>
+     *
+     * @param c   최댓값을 찾을 컬렉션 (null이 아니어야 함)
+     * @param <E> 컬렉션 요소의 타입 (Comparable을 구현해야 함)
+     * @return 컬렉션이 비어있으면 {@link Optional#empty()},
+     * 그렇지 않으면 최댓값을 담은 {@code Optional<E>}
+     * @throws NullPointerException 지정된 컬렉션이 null인 경우
+     *
+     * @implSpec
+     * 이 구현은 컬렉션을 순회하며 최댓값을 찾습니다. 시간 복잡도는 O(n)입니다.
+     */
     public static <E extends Comparable<E>> Optional<E> max(Collection<E> c) {
         if (c.isEmpty())
             return Optional.empty();
@@ -20,6 +35,13 @@ public class Max {
         return Optional.of(result);
     }
 
+    /**
+     * 컬렉션에서 최댓값을 반환합니다 (스트림 버전).
+     * * @param c   최댓값을 찾을 컬렉션
+     * @param <E> 컬렉션 요소의 타입
+     * @return 최댓값을 담은 Optional, 빈 컬렉션이면 빈 Optional
+     * @see #max(Collection)
+     */
     public static <E extends Comparable<E>> Optional<E> maxStream(Collection<E> c) {
         return c.stream().max(Comparator.naturalOrder());
     }


### PR DESCRIPTION
## 📘 [Item 56] 공개 API 요소에는 항상 문서화 주석을 작성하라

### 🔗 Related Issue

Closes #27 

---

### 🚩 Background

> Javadoc 작성의 중요성

* API 사용자가 소스 코드를 보지 않고도, 메서드의 기능, 입력값, 반환값, 예외 조건을 명확히 알 수 있어야 함.
* Item 55에서 작성한 `Max` 클래스에 표준 Javadoc이 누락되어 있음.

---

### ✅ Changes

> Javadoc 표준 태그 적용

* **Summary:** 메서드의 핵심 기능을 간결하게 요약.
* **`@param`, `@return`:** 매개변수와 반환값의 의미, 특히 `Optional` 반환 조건을 명시.
* **`@throws`:** 발생 가능한 예외(NPE) 명시.
* **`@implSpec`:** (Java 8+) 메서드의 내부 구현 방식(시간 복잡도 O(n) 등)과 계약 사항을 기술하여, 상속하거나 재사용하는 개발자에게 정보 제공.

```java
/**
 * ...
 * @return 컬렉션이 비어있으면 {@link Optional#empty()}
 * @implSpec 이 구현은 시간 복잡도 O(n)을 가집니다.
 */

```

---

### 📝 Review & Feedback

> AI(Gemini)와의 리뷰 과정에서 배운 점

* 코드를 짜는 것만큼이나, 남이 읽을 수 있게 설명하는 문서화(Documentation)가 중요하다.
* `{@link}` 태그를 활용하면 IDE에서 바로 이동 가능한 링크를 만들 수 있다.
* `@implSpec`을 통해 인터페이스나 메서드의 구현 동작 방식을 명세하는 표준적인 방법이 있음을 배움.