### PR TITLE
29 item 60 정확한 답이 필요하다면 float와 double은 피하라

### DIFF
--- a/src/main/java/org/jsh/chapter09/item60/CandyStore.java
+++ b/src/main/java/org/jsh/chapter09/item60/CandyStore.java
@@ -1,9 +1,13 @@
 package org.jsh.chapter09.item60;
 
+import java.math.BigDecimal;
+
 public class CandyStore {
 
-    // Bad: double을 사용한 금융 계산
-    public static double calculateChange(double funds, double price) {
-        return funds - price;
+    // Good: BigDecimal 을 사용한 금융 계산
+    public static BigDecimal calculateChange(double funds, double price) {
+        BigDecimal bd_funds = BigDecimal.valueOf(funds);
+        BigDecimal bd_price = BigDecimal.valueOf(price);
+        return bd_funds.subtract(bd_price);
     }
 }

--- a/src/main/java/org/jsh/chapter09/item60/CandyStore.java
+++ b/src/main/java/org/jsh/chapter09/item60/CandyStore.java
@@ -1,0 +1,9 @@
+package org.jsh.chapter09.item60;
+
+public class CandyStore {
+
+    // Bad: double을 사용한 금융 계산
+    public static double calculateChange(double funds, double price) {
+        return funds - price;
+    }
+}

--- a/src/test/java/org/jsh/chapter09/item60/CandyStoreTest.java
+++ b/src/test/java/org/jsh/chapter09/item60/CandyStoreTest.java
@@ -1,0 +1,26 @@
+package org.jsh.chapter09.item60;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
+
+class CandyStoreTest {
+
+    @Test
+    @DisplayName("double로 잔돈 계산 시 정밀도 문제 확인")
+    void doublePrecisionTest() {
+        // Given
+        double funds = 1.03;
+        double price = 0.42;
+
+        // When
+        double change = CandyStore.calculateChange(funds, price);
+
+        // Then
+        System.out.println("Result: " + change);
+        // 출력 예상: 0.6100000000000001
+
+        // 당연히 0.61이어야 하는데, 컴퓨터는 아니라고 함
+        assertThat(change).isNotEqualTo(0.61);
+    }
+}

--- a/src/test/java/org/jsh/chapter09/item60/CandyStoreTest.java
+++ b/src/test/java/org/jsh/chapter09/item60/CandyStoreTest.java
@@ -2,6 +2,9 @@ package org.jsh.chapter09.item60;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
 import static org.assertj.core.api.Assertions.*;
 
 class CandyStoreTest {
@@ -14,13 +17,13 @@ class CandyStoreTest {
         double price = 0.42;
 
         // When
-        double change = CandyStore.calculateChange(funds, price);
+        BigDecimal change = CandyStore.calculateChange(funds, price);
 
         // Then
         System.out.println("Result: " + change);
-        // 출력 예상: 0.6100000000000001
+        // 출력 예상: 0.61
 
-        // 당연히 0.61이어야 하는데, 컴퓨터는 아니라고 함
-        assertThat(change).isNotEqualTo(0.61);
+        // BigDecimal 로 결과 정답
+        assertThat(change).isEqualTo(BigDecimal.valueOf(0.61));
     }
 }


### PR DESCRIPTION
## 📘 [Item 60] 정확한 답이 필요하다면 float와 double은 피하라

### 🔗 Related Issue

Closes #29 

---

### 🚩 Problem (Before)

> 부동소수점(`float`, `double`) 타입의 정밀도 문제

* `1.03 - 0.42` 같은 간단한 실수 연산 시, 컴퓨터의 이진수 표현 한계로 인해 `0.6100000000000001` 같은 근사값이 반환됨.
* 금융 계산이나 정확한 수치가 필요한 로직에서 치명적인 오류를 유발할 수 있음.

---

### ✅ Solution (After)

> `BigDecimal` 도입

* 정확한 연산을 위해 `float`/`double` 대신 `java.math.BigDecimal`을 사용.
* `double` 값을 `BigDecimal`로 변환할 때, 오차를 방지하기 위해 `BigDecimal.valueOf(double)` (내부적으로 String 변환)을 사용.
* 연산 시 산술 연산자(`-`) 대신 `subtract()` 메서드 사용.

```java
// 정밀한 금융 계산을 위한 BigDecimal 적용
public static BigDecimal calculateChange(double funds, double price) {
    return BigDecimal.valueOf(funds).subtract(BigDecimal.valueOf(price));
}

```

---

### 📝 Review & Feedback

> AI(Gemini)와의 리뷰 과정에서 배운 점

* `new BigDecimal(double)` 생성자는 double의 근사값을 그대로 가져오므로 피해야 한다.
* 대신 `new BigDecimal(String)` 생성자나 `BigDecimal.valueOf(double)` 정적 팩터리 메서드를 사용해야 정확한 값이 보존된다.
* 금융 관련 계산에서는 기본형(`primitive type`) 사용을 지양하고 반드시 `BigDecimal`을 사용해야 한다.

---

### 🧪 Verification

* [x] `1.03 - 0.42` 계산 결과가 오차 없이 정확히 `0.61`로 나오는지 확인.