### PR TITLE
35 item 70 71 72 표준 예외와 비검사 예외를 사랑하라

### DIFF
--- a/src/main/java/org/jsh/chapter10/item70_item71_item72/Account.java
+++ b/src/main/java/org/jsh/chapter10/item70_item71_item72/Account.java
@@ -14,22 +14,17 @@ public class Account {
     // 1. 모든 예외가 Checked Exception이라 호출하는 쪽에서 try-catch 필수 (Item 70, 71 위반)
     // 2. 표준 예외(IllegalArgumentException)가 있는데 굳이 커스텀 예외 생성 (Item 72 위반)
     // 3. 자바 표준 예외가 아닌 엉뚱한 예외(InsufficientResourcesException) 사용 (Item 72 위반)
-    public void withdraw(int money) throws MyCustomInvalidMoneyException, InsufficientResourcesException {
+    public void withdraw(int money) {
         if (money <= 0) {
             // 돈이 음수일 수 없는데 굳이 Checked 예외를 던짐
-            throw new MyCustomInvalidMoneyException("출금액은 0보다 커야 합니다.");
+            throw new IllegalArgumentException("출금액은 0보다 커야 합니다.");
         }
 
         if (balance < money) {
             // 잔고 부족은 객체 상태 문제인데, 이름도 이상한 Checked 예외를 씀
-            throw new InsufficientResourcesException("잔고가 부족합니다.");
+            throw new IllegalStateException("잔고가 부족합니다.");
         }
 
         balance -= money;
-    }
-
-    // 설명을 위해 내부에 정의한 커스텀 체크 예외
-    public static class MyCustomInvalidMoneyException extends Exception {
-        public MyCustomInvalidMoneyException(String message) { super(message); }
     }
 }

--- a/src/test/java/org/jsh/chapter10/item70_item71_item72/AccountTest.java
+++ b/src/test/java/org/jsh/chapter10/item70_item71_item72/AccountTest.java
@@ -17,9 +17,9 @@ class AccountTest {
         // 실제 코드에서 호출할 땐 try-catch를 덕지덕지 발라야 함.
 
         assertThatThrownBy(() -> account.withdraw(-100))
-                .isInstanceOf(Account.MyCustomInvalidMoneyException.class);
+                .isInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> account.withdraw(2000))
-                .isInstanceOf(InsufficientResourcesException.class);
+                .isInstanceOf(IllegalStateException.class);
     }
 }


### PR DESCRIPTION
## 📘 [Part 2] 표준 예외와 런타임 예외 사용하기 (Item 70~72)

### 🔗 Related Issue

Closes #35 

---

### 🚩 Problem (Before)

> 과도한 체크 예외(Checked Exception) 및 커스텀 예외 남발

* **Item 70, 71 위반:** 단순히 금액이 음수이거나 잔고가 부족한 상황은 프로그래밍 오류거나 클라이언트가 미리 확인 가능한 상태임에도, `Checked Exception`을 던져 클라이언트에게 불필요한 `try-catch` 처리를 강제함.
* **Item 72 위반:** 자바 표준 라이브러리에 이미 존재하는 예외(`IllegalArgumentException`) 대신 불필요한 커스텀 예외(`MyCustomInvalidMoneyException`)를 생성하여 클래스 로딩 비용을 증가시키고 API 학습 난이도를 높임.

```java
// Bad: 호출하는 쪽을 괴롭히는 throws 선언
public void withdraw(int money) throws MyCustomInvalidMoneyException, InsufficientResourcesException { ... }

```

---

### ✅ Solution (After)

> 표준 런타임 예외(Standard Runtime Exception) 도입

* **Refactoring:** 모든 예외를 **Unchecked Exception(런타임 예외)** 로 변경하여 `throws` 선언을 제거하고 클라이언트 코드를 깔끔하게 만듦.
* **Standard Exceptions:**
* 잘못된 인자(음수 금액) -> **`IllegalArgumentException`** 사용.
* 객체의 잘못된 상태(잔고 부족) -> **`IllegalStateException`** 사용.


* **Cleanup:** 불필요한 커스텀 예외 클래스 삭제.

```java
// Good: 명확하고 깔끔한 시그니처, 표준 예외 사용
public void withdraw(int money) {
    if (money <= 0) {
        throw new IllegalArgumentException("출금액은 0보다 커야 합니다.");
    }
    if (balance < money) {
        throw new IllegalStateException("잔고가 부족합니다.");
    }
    balance -= money;
}

```

---

### 📝 Review & Feedback

> AI(Gemini)와의 리뷰 과정에서 배운 점

* **복구 불가능하면 런타임 예외:** API 사용자가 예외를 잡아서 복구할 수 있는 경우가 아니라면, 비검사 예외(Unchecked Exception)를 사용하는 것이 정석이다.
* **표준 예외를 사랑하라:** `IllegalArgumentException`, `IllegalStateException` 등 표준 예외를 사용하면 다른 개발자가 API를 이해하기 쉽고 메모리 효율도 좋아진다.
* **"인자" vs "상태":** 값이 이상하면 `Argument`, 상황이 안 맞으면 `State` 예외를 던지는 기준을 확립함.

---

### 🧪 Verification

* [x] `AccountTest`에서 `withdraw` 호출 시:
* 음수 입력 -> `IllegalArgumentException` 발생 확인
* 잔고 초과 -> `IllegalStateException` 발생 확인